### PR TITLE
WSLをスリープしないようにする

### DIFF
--- a/playbook/wsl.yaml
+++ b/playbook/wsl.yaml
@@ -31,7 +31,7 @@
       notify: restart systemd-timesyncd
 
 - name: keep wsl alive
-  # from https://github.com/microsoft/WSL/issues/8854#issuecomment-1490454734
+  # from https://github.com/microsoft/WSL/issues/10138#issuecomment-2380431569
   become: true
   block:
     - name: put service file
@@ -43,8 +43,7 @@
           Description=Keep Distro Alive
 
           [Service]
-          ExecStartPre=/mnt/c/Windows/System32/waitfor.exe /si MakeDistroAlive
-          ExecStart=/mnt/c/Windows/System32/waitfor.exe MakeDistroAlive
+          ExecStart=/mnt/c/Windows/System32/wsl.exe sleep infinity
 
           [Install]
           WantedBy=multi-user.target

--- a/playbook/wsl.yaml
+++ b/playbook/wsl.yaml
@@ -29,3 +29,27 @@
           [Unit]
           ConditionVirtualization=
       notify: restart systemd-timesyncd
+
+- name: keep wsl alive
+  # from https://github.com/microsoft/WSL/issues/8854#issuecomment-1490454734
+  become: true
+  block:
+    - name: put service file
+      blockinfile:
+        path: /etc/systemd/system/keep_wsl_alive.service
+        create: true
+        block: |
+          [Unit]
+          Description=Keep Distro Alive
+
+          [Service]
+          ExecStartPre=/mnt/c/Windows/System32/waitfor.exe /si MakeDistroAlive
+          ExecStart=/mnt/c/Windows/System32/waitfor.exe MakeDistroAlive
+
+          [Install]
+          WantedBy=multi-user.target
+    - name: enable
+      systemd:
+        name: keep_wsl_alive.service
+        enabled: true
+        state: started


### PR DESCRIPTION
どっかのバージョンから、WSLは使ってないときに自動スリープするようになった。ターミナルをちょいちょい片付ける身としては頻繁に起動オーバーヘッドを待たされるのはつらいので、対策。

この挙動について、公式をそれを無効化するオプションを提供する気が無いようなので、issueから謎パッチを拾ってきて対応。
謎パッチなので対処法はいくつもあったが、dotfilesでコード管理しやすい・シンプルでわかりやすい解を選択。